### PR TITLE
1.2

### DIFF
--- a/src/sass/base/_modal-components.scss
+++ b/src/sass/base/_modal-components.scss
@@ -9,7 +9,7 @@
   padding: 15px 30px;
   overflow-y: scroll;
   z-index: 1;
-  &.modal is-hidden {
+  &.modal-is-hidden {
     pointer-events: none;
     opacity: 0;
     transition: opacity 250ms cubic-bezier(0.4, 0, 0.2, 1);


### PR DESCRIPTION
.backdrop {
  position: fixed;
  top: 0;
  left: 0;
  width: 100%;
  height: 100%;
  opacity: 1;
  background: rgba(0, 0, 0, 0.4);
  padding: 15px 30px;
  overflow-y: scroll;
  z-index: 1;
  &.modal-is-hidden {
    pointer-events: none;
    opacity: 0;
    transition: opacity 250ms cubic-bezier(0.4, 0, 0.2, 1);
  }
}
body.modal-open {
  overflow: hidden;
}
  &.modal-is-hidden   тут  убрал дефис  между modal-is